### PR TITLE
Updated uploader to fit to the new bibsonomy behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # bibsonomy-uploader
 Our simple Java command line tool for uploading bibtex files to bibsonomy
 
-## Build
-Its plain maven.
+## Building the jar
+
+You'll need a JDK 11 or later to build the application.  Use the following command:
 
 ```bash
-mvn clean install
+mvn clean compile assembly:single
 ```
+
+
+## Running 
+
+```
+java --add-opens java.base/sun.misc=ALL-UNNAMED -jar <jar_file.jar> <username> <apikey> <apiurl> <bibtex-file>
+```
+
+
+## Debian Package
 
 ## Usage
 
@@ -16,35 +27,6 @@ A bundled jar file is generated under `bibsonomy-uploader-debian-cli/target`, th
 ```bash
 java -cp `find bibsonomy-uploader-debian-cli/target -name 'bibsonomy-uploader*jar'` org.aksw.bibuploader.BibUpdater username apikey apiurl bibtex-file
 ```
-
-## Running on Java 11+ (tested up to 22.0.2)
-
-Since JAXB was removed from the JDK starting with Java 11, you need to add JAXB at runtime and disable JAXB's bytecode optimization. No code changes are required.
-
-1. Add JAXB dependencies (download JARs into a local `lib/` folder)
-  - `jakarta.xml.bind-api-2.3.3.jar`
-  - `jaxb-runtime-2.3.3.jar` (from `org.glassfish.jaxb`)
-  - `jakarta.activation-api-1.2.2.jar`
-  > Ensure the `lib/` directory sits next to your runnable JAR (or adjust the path accordingly).
-2. Run using classpath + main class (not `-jar`)
-  ```bash
-    java \
-      --add-opens java.base/sun.misc=ALL-UNNAMED \
-      -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true \
-      -cp "<YOUR_JAR>:lib/*" \
-      org.aksw.bibuploader.BibUpdater <username> <apikey> <apiurl> <bibtex-file>
-  ```
-  > Note: On Windows, use `;` insted of `:` in the `-cp` argument.
-
-## Building the jar
-
-mvn clean compile assembly:single
-
-## Note, only executable with Java 1-8-101 or higher
-
-java --add-modules java.xml.bind -jar target/bibsonomy-uploader-cli-0.9.0-SNAPSHOT-jar-with-dependencies.jar aksw "insertAPIkeyHERE" "http://www.bibsonomy.org/api" ~/Papers/bib/aksw.bib 
-
-## Debian Package
 
 ### Removing and (re-)installing the Debian package
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,32 @@ mvn clean install
 
 ## Usage
 
-A bundled jar file is generated under `bibsonomy-uploader-debian-cli/target`, therfore, from the project root directory it can be run with:
+A bundled jar file is generated under `bibsonomy-uploader-debian-cli/target`, therefore, from the project root directory it can be run with:
 
 
 ```bash
 java -cp `find bibsonomy-uploader-debian-cli/target -name 'bibsonomy-uploader*jar'` org.aksw.bibuploader.BibUpdater username apikey apiurl bibtex-file
 ```
+
+## Running on Java 11+ (tested up to 22.0.2)
+
+Since JAXB was removed from the JDK starting with Java 11, you need to add JAXB at runtime and disable JAXB's bytecode optimization. No code changes are required.
+
+1. Add JAXB dependencies (download JARs into a local `lib/` folder)
+  - `jakarta.xml.bind-api-2.3.3.jar`
+  - `jaxb-runtime-2.3.3.jar` (from `org.glassfish.jaxb`)
+  - `jakarta.activation-api-1.2.2.jar`
+  > Ensure the `lib/` directory sits next to your runnable JAR (or adjust the path accordingly).
+2. Run using classpath + main class (not `-jar`)
+  ```bash
+    java \
+      --add-opens java.base/sun.misc=ALL-UNNAMED \
+      -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true \
+      -cp "<YOUR_JAR>:lib/*" \
+      org.aksw.bibuploader.BibUpdater <username> <apikey> <apiurl> <bibtex-file>
+  ```
+  > Note: On Windows, use `;` insted of `:` in the `-cp` argument.
+
 ## Building the jar
 
 mvn clean compile assembly:single

--- a/bibsonomy-uploader-cli/pom.xml
+++ b/bibsonomy-uploader-cli/pom.xml
@@ -53,6 +53,12 @@
 	  <artifactId>javax.activation</artifactId>
 	  <version>1.2.0</version>
 	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.javers/javers-core -->
+	<dependency>
+	    <groupId>org.javers</groupId>
+	    <artifactId>javers-core</artifactId>
+	    <version>5.9.2</version>
+	</dependency>
     </dependencies>
 </project>
 

--- a/bibsonomy-uploader-cli/pom.xml
+++ b/bibsonomy-uploader-cli/pom.xml
@@ -33,32 +33,36 @@
             <artifactId>junit</artifactId>
         </dependency>
 
-	<dependency>
-	  <groupId>javax.xml.bind</groupId>
-	  <artifactId>jaxb-api</artifactId>
-	  <version>2.3.0</version>
-	</dependency>
-	<dependency>
-	  <groupId>com.sun.xml.bind</groupId>
-	  <artifactId>jaxb-core</artifactId>
-	  <version>2.3.0</version>
-	</dependency>
-	<dependency>
-	  <groupId>com.sun.xml.bind</groupId>
-	  <artifactId>jaxb-impl</artifactId>
-	  <version>2.3.0</version>
-	</dependency>
-	<dependency>
-	  <groupId>com.sun.activation</groupId>
-	  <artifactId>javax.activation</artifactId>
-	  <version>1.2.0</version>
-	</dependency>
-	<!-- https://mvnrepository.com/artifact/org.javers/javers-core -->
-	<dependency>
-	    <groupId>org.javers</groupId>
-	    <artifactId>javers-core</artifactId>
-	    <version>5.9.2</version>
-	</dependency>
+		<!-- https://mvnrepository.com/artifact/org.javers/javers-core -->
+		<dependency>
+			<groupId>org.javers</groupId>
+			<artifactId>javers-core</artifactId>
+			<version>5.9.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>4.0.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
+			<version>2.1.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
     </dependencies>
 </project>
 

--- a/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/BibUpdater.java
+++ b/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/BibUpdater.java
@@ -205,14 +205,10 @@ public class BibUpdater {
 		
 		// present in B and in F, updates based on file entry if different
 		List<Post<BibTex>> intersection = getPaperIntersection(fileEntries, accountEntries);
-		//int alCount = 0;
 		for(Post<BibTex> post:intersection) {
 			Post<BibTex> matchingPost = accountEntries.stream().filter(a -> a.getResource().getIntraHash().equals(post.getResource().getIntraHash()))
 					.findFirst().orElse(null);
-			if(post.getResource().getTitle().equals("FAIR.ReD: Semantic knowledge graph infrastructure for the life sciences"))
-				System.out.println();
 			if(matchingPost != null && isSame(matchingPost, post)) {
-				//alCount++;
 				log.info(post.getResource().getTitle() + " already there");
 			} else {
 				updateEntry(post);
@@ -275,6 +271,9 @@ public class BibUpdater {
 	
 	public boolean isSame(Post<BibTex> accountEntry, Post<BibTex> filePost) {
 		
+		if(filePost.getTags()==null||filePost.getTags().isEmpty())
+			filePost.addTag("nokeyword");
+		
 		Javers javers = JaversBuilder.javers().build();
 		Diff diff = javers.compare(accountEntry, filePost);
 		
@@ -284,8 +283,6 @@ public class BibUpdater {
 		for (Change curChange : changes) {
 			String typeName = curChange.getAffectedGlobalId().getTypeName();
 			if (curChange instanceof ObjectRemoved) {
-				if(typeName.equals("org.bibsonomy.model.Tag") && accountEntry.getTags().contains(new Tag("nokeyword"))) 
-					continue;
 				if(!(typeName.equals("org.bibsonomy.model.Group") || typeName.equals("org.bibsonomy.model.User"))) 
 					return false;
 			} else if (curChange instanceof ValueChange) {
@@ -298,8 +295,6 @@ public class BibUpdater {
 					return false;
 			} else if (curChange instanceof SetChange) {
 				String propertyName = ((SetChange) curChange).getPropertyName();
-				if(typeName.equals("org.bibsonomy.model.Post") && propertyName.equals("tags") && accountEntry.getTags().contains(new Tag("nokeyword")))
-					continue;
 				if(!(typeName.equals("org.bibsonomy.model.Post") && propertyName.equals("groups"))) 
 					return false;
 			} else {

--- a/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/Summary.java
+++ b/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/Summary.java
@@ -1,0 +1,65 @@
+package org.aksw.bibuploader;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Summary {
+	private Set<String> duplicates;
+	private int sucAdded;
+	private Set<String> failedAdditions;
+	private int noUpdated;
+	private int noRemoved;
+	private Set<String> noTagEntries;
+
+	public Summary() {
+		duplicates = new HashSet<String>();
+		failedAdditions = new HashSet<String>();
+		noTagEntries = new HashSet<String>();
+	}
+
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("\nDuplicates found in the given file:\n");
+		for (String duplicate : duplicates)
+			builder.append(duplicate.toString()).append("\n");
+
+		builder.append("\nPosts without keywords in the given file:\n");
+		for (String missingTag : noTagEntries)
+			builder.append(missingTag.toString()).append("\n");
+
+		builder.append("\nSummary:\n");
+		builder.append(duplicates.size()).append("\tDuplicates found in the given file (see titles above)\n");
+		builder.append(noTagEntries.size()).append("\tPosts without keywords in the given file (see titles above)\n");
+		builder.append(sucAdded).append("\tPapers were added to bibsonomy\n");
+		builder.append(failedAdditions.size()).append("\tPapers couldn't be added\n");
+		
+		builder.append(noRemoved).append("\tPapers were deleted from bibsonomy\n");
+		builder.append(noUpdated).append("\tPapers were updated\n\n");
+
+		return builder.toString();
+	}
+
+	public void addDuplicate(String dup) {
+		duplicates.add(dup);
+	}
+
+	public void addNoTagEntry(String missingTagEntry) {
+		noTagEntries.add(missingTagEntry);
+	}
+
+	public void addSucAdd() {
+		sucAdded++;
+	}
+
+	public void addFailAdd(String failed) {
+		failedAdditions.add(failed);
+	}
+
+	public void addUpdate() {
+		noUpdated++;
+	}
+
+	public void setRemoved(int removed) {
+		noRemoved = removed;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,9 @@
 
 
     <properties>
-        <bibsonomy.version>3.8.8</bibsonomy.version>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <bibsonomy.version>3.9.2</bibsonomy.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <file.encoding>UTF-8</file.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -53,7 +52,7 @@
 
 
     <build>
-        <plugins>
+        <plugins>        
             <!-- That's a sledge hammer solution - but at least it works ... -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -117,20 +116,20 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
-            <configuration>
-                <archive>
-                <manifest>
-                    <mainClass>
-                       org.aksw.bibuploader.BibUpdater
-                    </mainClass>
-                </manifest>
-                </archive>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-            </configuration>
+	            <configuration>
+	                <archive>
+	                <manifest>
+	                    <mainClass>
+	                       org.aksw.bibuploader.BibUpdater
+	                    </mainClass>
+	                </manifest>
+	                </archive>
+	                <descriptorRefs>
+	                    <descriptorRef>jar-with-dependencies</descriptorRef>
+	                </descriptorRefs>
+	                
+	            </configuration>
             </plugin>
-
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -138,9 +137,9 @@
                 <version>2.19</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <!-- <forkCount>1C</forkCount> -->
-                    <!-- <reuseForks>true</reuseForks> -->
-                    <!-- <forkMode>pertest</forkMode> <argLine>-Xms256m -Xmx512m</argLine> -->
+					<!-- <forkCount>1C</forkCount> -->
+					<!-- <reuseForks>true</reuseForks> -->
+					<!-- <forkMode>pertest</forkMode> <argLine>-Xms256m -Xmx512m</argLine> -->
                     <testFailureIgnore>false</testFailureIgnore>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -152,7 +151,7 @@
         <repository>
             <id>bibsonomy-repo</id>
             <name>Releases von BibSonomy-Modulen</name>
-            <url>http://dev.bibsonomy.org/maven2/</url>
+            <url>https://dev.bibsonomy.org/maven2/</url>
         </repository>
     </repositories>
 
@@ -176,11 +175,11 @@
                 </exclusions>
             </dependency>
 
-            <!-- <dependency> -->
-            <!-- <groupId>xml-apis</groupId> -->
-            <!-- <artifactId>xml-apis</artifactId> -->
-            <!-- <version>1.3.03</version> -->
-            <!-- </dependency> -->
+			<!-- <dependency> -->
+			<!-- <groupId>xml-apis</groupId> -->
+			<!-- <artifactId>xml-apis</artifactId> -->
+			<!-- <version>1.3.03</version> -->
+			<!-- </dependency> -->
 
             <dependency>
                 <groupId>org.bibsonomy</groupId>
@@ -205,7 +204,7 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
-                <!-- scope>test</scope -->
+				<!-- scope>test</scope -->
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Bibsonomy does not seem to accept copies of papers, anymore. This leads to the situation that for example tags of papers can not be updated with the current version of the uploader since the bibsonomy API simply rejects the request to add a "new" paper. To this end, @aalexandrasilva implemented a smarter behavior of the uploader as follows:
* Adding the paper to bibsonomy, if present in the file and not yet uploaded
* Removing the paper from bibsonomy, if absent in the file
* Updating the papers that are present in the file and in bibsonomy, but have differences (used javers library to check the differences).
* Generate a summary at the end of the update process

Notes:
* Since bibsonomy seems to modify some attributes while uploading, we considered 2 papers the same if they have the same intrahash, and only these attributes differ between them.
* The previous implementation was not fetching all posts from bibsonomy, since the API only allows 1000 entries to be fetched at a time. We added a method as to retrieve all entries.